### PR TITLE
TEL-5695 set uv and mise to the same explicit python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{ name = "Team Telemetry", email = "telemetry@digital.hmrc.gov.uk" }]
 license = "Apache 2.0"
 maintainers = [{ name = "Team Telemetry", email = "telemetry@digital.hmrc.gov.uk" }]
 readme = "README.md"
-requires-python = ">=3.14,<3.15"
+requires-python = "==3.14.6"
 
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/uv.lock
+++ b/uv.lock
@@ -1,10 +1,10 @@
 version = 1
 revision = 3
-requires-python = "==3.14.*"
+requires-python = "==3.14.6"
 
 [[package]]
 name = "aws-lambda-clickhouse-config-in-zookeeper"
-version = "0.0.0"
+version = "1.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aws-lambda-powertools" },


### PR DESCRIPTION
What did we do?
--

1. set `requires-python` for `uv` to explicitly match mise's python version

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-5695

Collaboration
--

Co-authored-by: @duddingl
